### PR TITLE
Source config after plugins

### DIFF
--- a/.zsh_plugins.txt
+++ b/.zsh_plugins.txt
@@ -51,10 +51,10 @@ mattmc3/zephyr path:plugins/completions
 ### fish-like lazy-load functions
 mattmc3/zfunctions
 
-### fish-like conf.d
-mattmc3/zshrc.d
-
 ### fish-like core plugins
 zsh-users/zsh-autosuggestions
 zsh-users/zsh-syntax-highlighting
 zsh-users/zsh-history-substring-search
+
+### fish-like conf.d
+mattmc3/zshrc.d


### PR DESCRIPTION
Fixes an error I'm having on a fresh install:
```
zsh-syntax-highlighting: unhandled ZLE widget 'history-substring-search-up'
zsh-syntax-highlighting: (This is sometimes caused by doing `bindkey <keys> history-substring-search-up` without creating the 'history-substring-search-up' widget with `zle -N` or `zle -C`.)
zsh-syntax-highlighting: unhandled ZLE widget 'history-substring-search-down'
zsh-syntax-highlighting: (This is sometimes caused by doing `bindkey <keys> history-substring-search-down` without creating the 'history-substring-search-down' widget with `zle -N` or `zle -C`.)
```

Which according to https://github.com/zsh-users/zsh-syntax-highlighting/issues/411#issuecomment-317077561
can be fixed by setting keybinds (zshrc.d/history-substring-search.zsh) after sourcing the plugins