### PR TITLE
Fiz zoxide eval

### DIFF
--- a/.zshrc.d/zoxide.zsh
+++ b/.zshrc.d/zoxide.zsh
@@ -1,2 +1,2 @@
 (( $+commands[zoxide] )) || return 1
-eval $(zoxide init zsh)
+eval "$(zoxide init zsh)"


### PR DESCRIPTION
I have tested this zdotdir example config as is and noted that the zoxide `z` function doesn't work out of the box.

By quoting the `eval` statement of zoxide init, this is now working currently with no other changes needed.